### PR TITLE
set temporary params on db; aligned public key usage on registration …

### DIFF
--- a/pbtx-key-provider/src/androidTest/java/com/pbtx/PbtxClientTest.kt
+++ b/pbtx-key-provider/src/androidTest/java/com/pbtx/PbtxClientTest.kt
@@ -2,6 +2,7 @@ package com.pbtx
 
 import android.util.Log
 import androidx.test.runner.AndroidJUnit4
+import com.pbtx.utils.PbtxUtils
 import org.junit.*
 import org.junit.rules.ExpectedException
 import org.junit.runner.RunWith
@@ -25,7 +26,7 @@ class PbtxClientTest {
         val keyName = randomKeyName()
         val key = PbtxClient.createKey(keyName)
 
-        Log.d("EKisTest", "Key :: " + key.toHexString())
+        Log.d("EKisTest", "Key :: ${PbtxUtils.bytesToHexString(key)}")
         Assert.assertNotNull(key)
 
         // Check if the key present in the size
@@ -52,7 +53,8 @@ class PbtxClientTest {
         val keyList = PbtxClient.listKeys()
 
         keyList.forEach {
-            Log.d("EKisTest", "Key :: " + it.publicKey.toByteArray().toHexString())
+            val publicKeyBytes = it.publicKey.keyBytes.toByteArray()
+            Log.d("EKisTest", "Key :: ${PbtxUtils.bytesToHexString(publicKeyBytes)}")
         }
         assert(keyList.size == initialKeyListSize + 2)
 
@@ -70,31 +72,16 @@ class PbtxClientTest {
         PbtxClient.createKey(keyName)
 
         // Signing data
-        val signature: ByteArray? = PbtxClient.signData(
-            "0102030405060708090a0b0c0d0e0f".decodeHex(),
+        val data = "0102030405060708090a0b0c0d0e0f"
+        val signature: ByteArray = PbtxClient.signData(
+            PbtxUtils.decodeHex(data),
             keyName
         )
-        Log.d("EKisTest", "Signature ${signature?.toHexString()}")
+        Log.d("EKisTest", "Signature ${PbtxUtils.bytesToHexString(signature)}")
         Assert.assertNotNull(signature)
 
         // Cleanup
         PbtxClient.deleteKey(keyName)
-    }
-
-    private fun String.decodeHex(): ByteArray {
-        check(length % 2 == 0) { "Must have an even length" }
-
-        val byteIterator = chunkedSequence(2)
-            .map { it.toInt(16).toByte() }
-            .iterator()
-
-        return ByteArray(length / 2) { byteIterator.next() }
-    }
-
-    private fun ByteArray.toHexString(): String {
-        return this.joinToString("") {
-            java.lang.String.format("%02x", it)
-        }
     }
 
     private fun randomKeyName(): String {

--- a/pbtx-key-provider/src/androidTest/java/com/pbtx/PbtxDatabaseTest.kt
+++ b/pbtx-key-provider/src/androidTest/java/com/pbtx/PbtxDatabaseTest.kt
@@ -23,7 +23,7 @@ class PbtxDatabaseTest : TestCase() {
     }
 
     @Test
-    fun updateLocalSyncHeadTest() {
+    fun registrationFlowTest() {
         val networkId = 100L
         val actor = ThreadLocalRandom.current().nextLong()
         var seqNum = 0

--- a/pbtx-key-provider/src/main/java/com/pbtx/PbtxClient.kt
+++ b/pbtx-key-provider/src/main/java/com/pbtx/PbtxClient.kt
@@ -17,6 +17,7 @@ import com.pbtx.persistence.entities.RegistrationStatus
 import com.pbtx.utils.KeyStoreProvider
 import com.pbtx.utils.KeyStoreProvider.Companion.generateAndroidKeyStoreKey
 import com.pbtx.utils.KeyStoreProvider.Companion.getCompressedPublicKey
+import com.pbtx.utils.PbtxUtils
 import com.pbtx.utils.PbtxUtils.Companion.additionByteAdd
 import com.pbtx.utils.ProtobufProvider
 import com.pbtx.utils.SignatureProvider.Companion.getCanonicalSignature
@@ -37,7 +38,8 @@ class PbtxClient constructor(context: Context) {
 
     fun initRegistration(): KeyModel {
         val keyModel = createRandomKey()
-        val registrationRecord = RegistrationRecord(keyModel.publicKey.keyBytes.toString(), keyModel.alias)
+        val publicKeyString = PbtxUtils.bytesToHexString(keyModel.publicKey.keyBytes.toByteArray())
+        val registrationRecord = RegistrationRecord(publicKeyString, keyModel.alias)
         registrationDao.insert(registrationRecord)
         return keyModel
     }
@@ -46,7 +48,7 @@ class PbtxClient constructor(context: Context) {
         val actor = permission.actor
         val weightedKey = permission.getKeys(0) //we expect only one key, used in registration/kyc process
             ?: throw Exception("A public key was not provided in the permission object")
-        val publicKeyString = weightedKey.key.keyBytes.toString()
+        val publicKeyString = PbtxUtils.bytesToHexString(weightedKey.key.keyBytes.toByteArray())
 
         val registrationRecord = registrationDao.getRegistrationRecord(publicKeyString)
             ?: throw Exception("Registration record not found for the provided public key = $publicKeyString")

--- a/pbtx-key-provider/src/main/java/com/pbtx/persistence/PbtxDatabase.kt
+++ b/pbtx-key-provider/src/main/java/com/pbtx/persistence/PbtxDatabase.kt
@@ -23,7 +23,8 @@ abstract class PbtxDatabase : RoomDatabase() {
             return INSTANCE ?: synchronized(this) {
                 return INSTANCE ?: run {
                     val instance = Room
-                        .inMemoryDatabaseBuilder(context, PbtxDatabase::class.java)
+                        .inMemoryDatabaseBuilder(context, PbtxDatabase::class.java) //TODO mcicu: use in-memory db only for tests
+                        .allowMainThreadQueries() //TODO mcicu: use co-routines to run asynchronous db requests
                         //.databaseBuilder(context, PbtxDatabase::class.java, "pbtx_database")
                         .build()
                     INSTANCE = instance

--- a/pbtx-key-provider/src/main/java/com/pbtx/persistence/entities/AccountRecord.kt
+++ b/pbtx-key-provider/src/main/java/com/pbtx/persistence/entities/AccountRecord.kt
@@ -9,6 +9,6 @@ data class AccountRecord(
     @ColumnInfo(name = "actor") val actor: Long,
     @ColumnInfo(name = "seq_number") var seqNumber: Int,
     @ColumnInfo(name = "prev_hash") var prevHash: Long,
-    @ColumnInfo(name = "public_key") var publicKey: String, //we expect only one key, used in registration/kyc process
+    @ColumnInfo(name = "public_key") var publicKey: String, //hex string representation of the key bytes
     @ColumnInfo(name = "key_alias") var keyAlias: String
 )

--- a/pbtx-key-provider/src/main/java/com/pbtx/utils/PbtxUtils.kt
+++ b/pbtx-key-provider/src/main/java/com/pbtx/utils/PbtxUtils.kt
@@ -21,6 +21,19 @@ class PbtxUtils {
             return destination
         }
 
+        fun decodeHex(input: String): ByteArray {
+            check(input.length % 2 == 0) { "Must have an even length" }
 
+            val byteIterator = input.chunkedSequence(2)
+                .map { it.toInt(16).toByte() }
+                .iterator()
+            return ByteArray(input.length / 2) { byteIterator.next() }
+        }
+
+        fun bytesToHexString(input: ByteArray): String {
+            return input.joinToString("") {
+                java.lang.String.format("%02x", it)
+            }
+        }
     }
 }


### PR DESCRIPTION
…to use the hex string representation, instead of bytes