### PR TITLE
clean-up naming for transaction history methods; 

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,14 +122,15 @@ private key owned locally by the account.
 3.1.8. `PbtxClient.actorSignData(networkId: Long, actor: Long, data: ByteArray): ByteArray`
 signs a given data using the actor's private key. It returns the signed data (i.e. the signature).
 
-3.1.9. `PbtxClient.getTransactionHistory(networkId: Long, actor: Long, pageNumber: Int, pageSize: Int): List<TransactionHistoryEntry>`
+3.1.9. `PbtxClient.getLocalTransactionHistory(networkId: Long, actor: Long, pageNumber: Int, pageSize: Int): List<TransactionHistoryEntry>`
 retrieves the history of transactions, paginated.
+The list of transactions is descending by backend_timestamp (i.e. most recent transaction is first in the list).
 It returns a sequence of `TransactionHistoryEntry` messages. For those transactions which were not
 confirmed by the network, `backend_timestamp` indicates the time when the user has signed the
 transaction, and `backend_trxid` is empty.
 
-3.1.10. `PbtxClient.storeTransactionHistoryEntry(networkId: Long, actor: Long, transactionHistoryEntry: TransactionHistoryEntry): Boolean`
-store a TransactionHistoryEntry. Returns false if the entry was already stored, and true otherwise.
+3.1.10. `PbtxClient.saveLocalTransactionHistoryEntry(networkId: Long, actor: Long, transactionHistoryEntry: TransactionHistoryEntry): Boolean`
+save a TransactionHistoryEntry. Returns false if the entry was already stored, and true otherwise.
 
 #### 3.2. Methods to implement
 

--- a/pbtx-android-module/src/androidTest/java/com/pbtx/PbtxDatabaseTest.kt
+++ b/pbtx-android-module/src/androidTest/java/com/pbtx/PbtxDatabaseTest.kt
@@ -4,6 +4,7 @@ package com.pbtx
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.pbtx.utils.PbtxUtils
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 import org.junit.Test
@@ -35,14 +36,7 @@ class PbtxDatabaseTest {
         val registrationKey = pbtxClient.initLocalRegistration()
 
         //creating Permission object
-        val weightedRegistrationKey = KeyWeight.newBuilder()
-            .setKey(registrationKey.publicKey)
-            .setWeight(1)
-            .build()
-        val permission = Permission.newBuilder()
-            .setActor(actor)
-            .addKeys(weightedRegistrationKey)
-            .build()
+        val permission = PbtxUtils.buildBasicPermissionForActor(actor, registrationKey.publicKey)
 
         //register account with default
         pbtxClient.registerLocalAccount(networkId, permission, seqNum, prevHash)

--- a/pbtx-android-module/src/main/java/com/pbtx/utils/PbtxUtils.kt
+++ b/pbtx-android-module/src/main/java/com/pbtx/utils/PbtxUtils.kt
@@ -1,5 +1,9 @@
 package com.pbtx.utils
 
+import pbtx.KeyWeight
+import pbtx.Permission
+import pbtx.PublicKey
+
 class PbtxUtils {
 
     companion object {
@@ -34,6 +38,17 @@ class PbtxUtils {
             return input.joinToString("") {
                 java.lang.String.format("%02x", it)
             }
+        }
+
+        fun buildBasicPermissionForActor(actor: Long, publicKey: PublicKey): Permission {
+            return Permission.newBuilder()
+                .setActor(actor)
+                .addKeys(
+                    KeyWeight.newBuilder()
+                        .setWeight(1)
+                        .setKey(publicKey)
+                )
+                .build()
         }
     }
 }

--- a/pbtx-android-module/src/main/java/com/pbtx/utils/mappers/TransactionHistoryMapper.kt
+++ b/pbtx-android-module/src/main/java/com/pbtx/utils/mappers/TransactionHistoryMapper.kt
@@ -8,6 +8,7 @@ class TransactionHistoryMapper {
 
     companion object {
 
+        //map to db record
         fun mapToTransactionHistoryRecord(networkId: Long, actor: Long, transactionHistoryEntry: TransactionHistoryEntry): TransactionHistoryRecord {
             return TransactionHistoryRecord(
                 networkId,
@@ -18,6 +19,7 @@ class TransactionHistoryMapper {
             )
         }
 
+        //map from db record
         fun mapToTransactionHistoryEntry(transactionHistoryRecord: TransactionHistoryRecord): TransactionHistoryEntry {
             return TransactionHistoryEntry.newBuilder()
                 .setTransaction(ByteString.copyFrom(transactionHistoryRecord.transaction))


### PR DESCRIPTION
- clean-up naming for transaction history methods;
-  new util to generate a basic permission object for actor